### PR TITLE
Automated cherry pick of #9: fix(kubeserver): sync cluster not fatal

### DIFF
--- a/pkg/kubeserver/app/app.go
+++ b/pkg/kubeserver/app/app.go
@@ -83,7 +83,8 @@ func Run(ctx context.Context) error {
 	}
 
 	if err := models.GetClusterManager().SyncClustersFromCloud(ctx); err != nil {
-		log.Fatalf("Sync clusters from cloud: %v", err)
+		// log.Fatalf("Sync clusters from cloud: %v", err)
+		log.Errorf("Sync clusters from cloud: %v", err)
 	}
 
 	if err := server.Start(httpsAddr, app); err != nil {

--- a/pkg/kubeserver/drivers/machines/yunion_vm.go
+++ b/pkg/kubeserver/drivers/machines/yunion_vm.go
@@ -579,6 +579,9 @@ func (d *sYunionVMDriver) GetInfoFromCloud(ctx context.Context, s *mcclient.Clie
 	if err != nil {
 		return nil, errors.Wrap(err, "get cloud server")
 	}
+	if srvObj == nil {
+		return nil, errors.Wrapf(errors.ErrNotFound, "machine %s cloud server %s not found", m.GetName(), id)
+	}
 	srvDetail := new(ocapi.ServerDetails)
 	if err := srvObj.Unmarshal(srvDetail); err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #9 on release/3.6.

#9: fix(kubeserver): sync cluster not fatal