### PR TITLE
Automated cherry pick of #26: fix(kubeserver): helm add repo already exists error

### DIFF
--- a/pkg/kubeserver/models/repos.go
+++ b/pkg/kubeserver/models/repos.go
@@ -161,6 +161,9 @@ func (man *SRepoManager) ValidateCreateData(ctx context.Context, userCred mcclie
 	}
 	if err := cli.Add(entry); err != nil {
 		log.Errorf("Add helm entry %#v error: %v", entry, err)
+		if errors.Cause(err) == helm.ErrRepoAlreadyExists {
+			return nil, httperrors.NewDuplicateResourceError("Backend helm repo name %s already exists, please specify a different name", data.Name)
+		}
 		return nil, httperrors.NewNotAcceptableError("Add helm repo %s failed", entry.URL)
 	}
 


### PR DESCRIPTION
Cherry pick of #26 on release/3.7.

#26: fix(kubeserver): helm add repo already exists error