### PR TITLE
Automated cherry pick of #30: fix(kubeserver): cluster ca and key field nullable deleted

### DIFF
--- a/pkg/kubeserver/models/clusters.go
+++ b/pkg/kubeserver/models/clusters.go
@@ -103,8 +103,8 @@ type SCluster struct {
 
 	// kubernetes config
 	Kubeconfig string `nullable:"true" charset:"utf8" create:"optional"`
-	Ca         string `nullable:"false" charset:"utf8" create:"optional"`
-	CaKey      string `nullable:"false" charset:"utf8" create:"optional"`
+	Ca         string `charset:"utf8" create:"optional"`
+	CaKey      string `charset:"utf8" create:"optional"`
 	// kubernetes api server endpoint
 	ApiServer string `width:"256" nullable:"true" charset:"ascii" create:"optional" list:"user"`
 


### PR DESCRIPTION
Cherry pick of #30 on release/3.6.

#30: fix(kubeserver): cluster ca and key field nullable deleted