### PR TITLE
Automated cherry pick of #51: fix(kubeserver): chart_ignores use regexp

### DIFF
--- a/pkg/kubeserver/options/options.go
+++ b/pkg/kubeserver/options/options.go
@@ -24,8 +24,8 @@ type KubeServerOptions struct {
 	// GuestDefaultTemplate string `help:"Guest kubernetes default image id" default:"k8s-centos7-base.qcow2"`
 	// GuestDefaultTemplate string `help:"Guest kubernetes default image id" default:"CentOS-7.6.1810-20190430.qcow2"`
 
-	// hack: repo charts filter
-	ChartIgnores []string `help:"Repo chart ignore config, e.g. 'vm-repo:onecloud-jenkins:0.2.0'"`
+	// hack: repo charts ignore regexp
+	ChartIgnores []string `help:"Repo chart ignore regexp config, e.g. '^vm-repo:onecloud-.*:0.2.0$'"`
 }
 
 func OnOptionsChange(oldO, newO interface{}) bool {


### PR DESCRIPTION
Cherry pick of #51 on release/3.7.

#51: fix(kubeserver): chart_ignores use regexp