### PR TITLE
Automated cherry pick of #119: fix(kubeserver): list by external_cluster_id and external_cloud_cluster_id

### DIFF
--- a/pkg/kubeserver/api/cluster.go
+++ b/pkg/kubeserver/api/cluster.go
@@ -220,11 +220,13 @@ type ClusterListInput struct {
 	apis.StatusDomainLevelResourceListInput
 	FederatedResourceUsedInput
 
-	ManagerId     string   `json:"manager_id"`
-	Manager       string   `json:"manager" yunion-deprecated-by:"manager_id"`
-	CloudregionId string   `json:"cloudregion_id"`
-	Provider      []string `json:"provider"`
-	Mode          ModeType `json:"mode"`
+	ManagerId              string   `json:"manager_id"`
+	Manager                string   `json:"manager" yunion-deprecated-by:"manager_id"`
+	ExternalClusterId      string   `json:"external_cluster_id"`
+	ExternalCloudClusterId string   `json:"external_cloud_cluster_id"`
+	CloudregionId          string   `json:"cloudregion_id"`
+	Provider               []string `json:"provider"`
+	Mode                   ModeType `json:"mode"`
 }
 
 type ClusterSyncInput struct {

--- a/pkg/kubeserver/models/clusters.go
+++ b/pkg/kubeserver/models/clusters.go
@@ -443,6 +443,12 @@ func (m *SClusterManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery
 	if input.CloudregionId != "" {
 		q = q.Equals("cloudregion_id", input.CloudregionId)
 	}
+	if input.ExternalClusterId != "" {
+		q = q.Equals("external_cluster_id", input.ExternalClusterId)
+	}
+	if input.ExternalCloudClusterId != "" {
+		q = q.Equals("external_cloud_cluster_id", input.ExternalCloudClusterId)
+	}
 
 	if len(input.Provider) != 0 {
 		providers := make([]string, len(input.Provider))


### PR DESCRIPTION
Cherry pick of #119 on master.

#119: fix(kubeserver): list by external_cluster_id and external_cloud_cluster_id