### PR TITLE
Automated cherry pick of #139: fix(kubeserver): not record ops log when resource_version updated

### DIFF
--- a/pkg/kubeserver/models/cluster_api.go
+++ b/pkg/kubeserver/models/cluster_api.go
@@ -96,6 +96,10 @@ func (a sClusterResAPI) UpdateFromRemoteObject(obj IClusterModel, ctx context.Co
 	if err != nil {
 		return errors.Wrapf(err, "Update from remote object error")
 	}
+	if _, ok := diff["resource_version"]; ok && len(diff) == 1 {
+		// not do OpsLog if only resource_version updated
+		return nil
+	}
 	db.OpsLog.LogSyncUpdate(obj, diff, userCred)
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #139 on release/3.8.

#139: fix(kubeserver): not record ops log when resource_version updated