### PR TITLE
Automated cherry pick of #171: fix(kubeserver): federated resource can't delete

### DIFF
--- a/pkg/kubeserver/models/federated_namespaces.go
+++ b/pkg/kubeserver/models/federated_namespaces.go
@@ -98,8 +98,8 @@ func (obj *SFedNamespace) GetDetails(base interface{}, isList bool) interface{} 
 // ValidateDeleteCondition check steps:
 // 1. no releated clusters attached
 // 2. no releated federated namespace scope resource
-func (obj *SFedNamespace) ValidateDeleteCondition(ctx context.Context) error {
-	if err := obj.SFedResourceBase.ValidateDeleteCondition(ctx); err != nil {
+func (obj *SFedNamespace) ValidateDeleteCondition(ctx context.Context, info jsonutils.JSONObject) error {
+	if err := obj.SFedResourceBase.ValidateDeleteCondition(ctx, info); err != nil {
 		return err
 	}
 	fedNsMans := GetFedJointNamespaceScopeManager()

--- a/pkg/kubeserver/models/federated_resource.go
+++ b/pkg/kubeserver/models/federated_resource.go
@@ -289,7 +289,7 @@ func (res *SFedResourceBase) PostUpdate(ctx context.Context, userCred mcclient.T
 	}
 }
 
-func (obj *SFedResourceBase) ValidateDeleteCondition(ctx context.Context) error {
+func (obj *SFedResourceBase) ValidateDeleteCondition(ctx context.Context, _ jsonutils.JSONObject) error {
 	clusters, err := GetFedResAPI().GetAttachedClusters(obj)
 	if err != nil {
 		return errors.Wrap(err, "get attached clusters")


### PR DESCRIPTION
Cherry pick of #171 on release/3.10.

#171: fix(kubeserver): federated resource can't delete