### PR TITLE
Automated cherry pick of #174: fix(kubeserver): deploy monitor stack addon for normal cluster

### DIFF
--- a/pkg/kubeserver/api/component.go
+++ b/pkg/kubeserver/api/component.go
@@ -183,10 +183,10 @@ type ComponentSettingVolume struct {
 }
 
 type ComponentSettingMonitorPromtail struct {
-	Disable           bool                   `json:"disable"`
-	Resources         *HelmValueResources    `json:"resources"`
-	DockerVolumeMount ComponentSettingVolume `json:"dockerVolumeMount"`
-	PodsVolumeMount   ComponentSettingVolume `json:"podsVolumeMount"`
+	Disable           bool                    `json:"disable"`
+	Resources         *HelmValueResources     `json:"resources"`
+	DockerVolumeMount *ComponentSettingVolume `json:"dockerVolumeMount"`
+	PodsVolumeMount   *ComponentSettingVolume `json:"podsVolumeMount"`
 }
 
 type HelmValueResource struct {

--- a/pkg/kubeserver/templates/components/monitor_promtheus.go
+++ b/pkg/kubeserver/templates/components/monitor_promtheus.go
@@ -333,11 +333,28 @@ type Loki struct {
 	Config  *LokiConfig `json:"config"`
 }
 
+type PromtailVolumeHostPath struct {
+	Path string `json:"path"`
+}
+
+type PromtailVolume struct {
+	Name     string                 `json:"name"`
+	HostPath PromtailVolumeHostPath `json:"hostPath"`
+}
+
+type PromtailVolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
+	ReadOnly  bool   `json:"readOnly"`
+}
+
 type Promtail struct {
 	Enabled      bool                    `json:"enabled"`
 	Resources    *api.HelmValueResources `json:"resources"`
 	BusyboxImage string                  `json:"busyboxImage"`
 	Image        Image                   `json:"image"`
+	Volumes      []*PromtailVolume       `json:"volumes"`
+	VolumeMounts []*PromtailVolumeMount  `json:"volumeMounts"`
 }
 
 type AdmissionWebhooksPatch struct {


### PR DESCRIPTION
Cherry pick of #174 on release/3.10.

#174: fix(kubeserver): deploy monitor stack addon for normal cluster