### PR TITLE
Automated cherry pick of #182: fix(kubeserver): sync clusters from cloud after client inited

### DIFF
--- a/pkg/kubeserver/app/app.go
+++ b/pkg/kubeserver/app/app.go
@@ -73,11 +73,6 @@ func Run(ctx context.Context) error {
 
 	httpsAddr := net.JoinHostPort(opt.Address, strconv.Itoa(opt.HttpsPort))
 
-	if err := models.GetClusterManager().SyncClustersFromCloud(ctx); err != nil {
-		// log.Fatalf("Sync clusters from cloud: %v", err)
-		log.Errorf("Sync clusters from cloud: %v", err)
-	}
-
 	cron := cronman.InitCronJobManager(true, options.Options.CronJobWorkerCount)
 	initial.InitClient(cron)
 	cron.Start()
@@ -85,6 +80,11 @@ func Run(ctx context.Context) error {
 
 	if err := models.GetClusterManager().RegisterSystemCluster(); err != nil {
 		log.Fatalf("Register system cluster %v", err)
+	}
+
+	if err := models.GetClusterManager().SyncClustersFromCloud(ctx); err != nil {
+		// log.Fatalf("Sync clusters from cloud: %v", err)
+		log.Errorf("Sync clusters from cloud: %v", err)
 	}
 
 	if err := server.Start(httpsAddr, app); err != nil {


### PR DESCRIPTION
Cherry pick of #182 on master.

#182: fix(kubeserver): sync clusters from cloud after client inited