### PR TITLE
Automated cherry pick of #191: fix(kubeserver): local-path-csi use v0.0.22

### DIFF
--- a/pkg/kubeserver/drivers/clusters/common.go
+++ b/pkg/kubeserver/drivers/clusters/common.go
@@ -78,7 +78,7 @@ func GetCommonAddonsConfig(cluster *models.SCluster) (*addons.YunionCommonPlugin
 		// 	Image:            registry.MirrorImage(reg.Url, "yunion-ingress-controller", "v2.10.0", ""),
 		// },
 		CSIRancherLocalPathConfig: &addons.CSIRancherLocalPathConfig{
-			Image:       registry.MirrorImage(reg.Url, "local-path-provisioner", "v0.0.11", ""),
+			Image:       registry.MirrorImage(reg.Url, "local-path-provisioner", "v0.0.22", ""),
 			HelperImage: registry.MirrorImage(reg.Url, "busybox", "1.28.0-glibc", ""),
 		},
 	}

--- a/scripts/offline/images.list
+++ b/scripts/offline/images.list
@@ -30,4 +30,5 @@ registry.cn-beijing.aliyuncs.com/yunionio/calico-pod2daemon-flexvol:v3.19.2
 registry.cn-beijing.aliyuncs.com/yunionio/etcd:v3.4.13
 
 registry.cn-beijing.aliyuncs.com/yunionio/yunion-cloud-controller-manager:v2.10.0
-registry.cn-beijing.aliyuncs.com/yunionio/local-path-provisioner:v0.0.11
+registry.cn-beijing.aliyuncs.com/yunionio/local-path-provisioner:v0.0.22
+registry.cn-beijing.aliyuncs.com/yunionio/busybox:1.28.0-glibc


### PR DESCRIPTION
Cherry pick of #191 on release/3.10.

#191: fix(kubeserver): local-path-csi use v0.0.22