### PR TITLE
Automated cherry pick of #222: Upgrade the HPA client version to support the highest version available for kubernetes client 1.17

### DIFF
--- a/pkg/kubeserver/client/api/types.go
+++ b/pkg/kubeserver/client/api/types.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	apps "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	// extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -76,8 +76,8 @@ var KindToResourceMap = map[string]ResourceMap{
 	api.ResourceNameHorizontalPodAutoscaler: {
 		GroupVersionResourceKind: GroupVersionResourceKind{
 			GroupVersionResource: schema.GroupVersionResource{
-				Group:    autoscalingv1.GroupName,
-				Version:  autoscalingv1.SchemeGroupVersion.Version,
+				Group:    autoscalingv2beta2.GroupName,
+				Version:  autoscalingv2beta2.SchemeGroupVersion.Version,
 				Resource: api.ResourceNameHorizontalPodAutoscaler,
 			},
 			Kind: api.KindNameHorizontalPodAutoscaler,

--- a/pkg/kubeserver/client/cache.go
+++ b/pkg/kubeserver/client/cache.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	apps "k8s.io/client-go/listers/apps/v1"
-	autoscalingv1 "k8s.io/client-go/listers/autoscaling/v1"
+	autoscalingv1 "k8s.io/client-go/listers/autoscaling/v2beta2"
 	batch "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/client-go/listers/core/v1"
 	rbac "k8s.io/client-go/listers/rbac/v1"
@@ -188,7 +188,7 @@ func (c *CacheFactory) EndpointLister() v1.EndpointsLister {
 }
 
 func (c *CacheFactory) HPALister() autoscalingv1.HorizontalPodAutoscalerLister {
-	return c.sharedInformerFactory.Autoscaling().V1().HorizontalPodAutoscalers().Lister()
+	return c.sharedInformerFactory.Autoscaling().V2beta2().HorizontalPodAutoscalers().Lister()
 }
 
 func (c *CacheFactory) GetGVKR(kindName string) *api.ResourceMap {

--- a/pkg/kubeserver/client/clientfactory.go
+++ b/pkg/kubeserver/client/clientfactory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	apps "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -41,7 +41,13 @@ func (h *resourceHandler) getClientByGroupVersion(resource api.ResourceMap) rest
 			return h.client.AppsV1().RESTClient()
 		}
 		return h.client.AppsV1beta1().RESTClient()
-	case autoscalingv1.GroupName:
+	case autoscalingv2beta2.GroupName:
+		if resource.GroupVersionResourceKind.Version == "v2beta1" {
+			return h.client.AutoscalingV2beta1().RESTClient()
+		}
+		if resource.GroupVersionResourceKind.Version == "v2beta2" {
+			return h.client.AutoscalingV2beta2().RESTClient()
+		}
 		return h.client.AutoscalingV1().RESTClient()
 	case batchv1.GroupName:
 		if resource.GroupVersionResourceKind.Version == "v1beta1" {

--- a/pkg/kubeserver/resources/common/resourcechannels.go
+++ b/pkg/kubeserver/resources/common/resourcechannels.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	apps "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	// extensions "k8s.io/api/extensions/v1beta1"


### PR DESCRIPTION
Cherry pick of #222 on release/3.9.

#222: Upgrade the HPA client version to support the highest version available for kubernetes client 1.17