### PR TITLE
Automated cherry pick of #240: fix(kubeserver): delete empty address machine

### DIFF
--- a/pkg/kubeserver/models/machines.go
+++ b/pkg/kubeserver/models/machines.go
@@ -477,6 +477,11 @@ func (m *SMachine) RealDelete(ctx context.Context, userCred mcclient.TokenCreden
 }
 
 func (m *SMachine) CustomizeDelete(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
+	if m.Address == "" {
+		log.Warningf("Machine %q address is empty, delete it directly", m.GetName())
+		return m.RealDelete(ctx, userCred)
+	}
+
 	cluster, err := m.GetCluster()
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #240 on release/3.10.

#240: fix(kubeserver): delete empty address machine