### PR TITLE
Automated cherry pick of #243: feat: use kubespray v2.19.1 to deploy k8s 1.22

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "manifests/ansible/kubespray_2_17_0"]
 	path = manifests/ansible/kubespray_2_17_0
 	url = https://github.com/zexi/kubespray
+[submodule "manifests/ansible/kubespray_2_19_1"]
+	path = manifests/ansible/kubespray_2_19_1
+	url = https://github.com/zexi/kubespray.git

--- a/pkg/kubeserver/constants/constants.go
+++ b/pkg/kubeserver/constants/constants.go
@@ -8,28 +8,32 @@ const (
 
 // version dependencies are named after the k8s version number
 const (
-	K8S_VERSION_1_17_0 = "v1.17.0"
-	K8S_VERSION_1_20_0 = "v1.20.0"
-)
-
-const (
-	CNI_VERSION_1_17_0 = "v0.8.6"
-	CNI_VERSION_1_20_0 = "v0.9.1"
-)
-
-const (
-	CALICO_VERSION_1_17_0 = "v3.16.5"
-	CALICO_VERSION_1_20_0 = "v3.19.2"
-)
-
-const (
 	KUBESPRAY_VERSION_1_17_0 = "kubespray"
+	K8S_VERSION_1_17_0       = "v1.17.0"
+	CALICO_VERSION_1_17_0    = "v3.16.5"
+	CNI_VERSION_1_17_0       = "v0.8.6"
+)
+
+const (
 	KUBESPRAY_VERSION_1_20_0 = "kubespray_2_17_0"
+	K8S_VERSION_1_20_0       = "v1.20.0"
+	CNI_VERSION_1_20_0       = "v0.9.1"
+	CALICO_VERSION_1_20_0    = "v3.19.2"
 )
 
 const (
 	NGINX_INGRESS_CONTROLLER_1_17_0 = "v0.41.2"
 	NGINX_INGRESS_CONTROLLER_1_20_0 = "v1.0.0"
+)
+
+const (
+	KUBESPRAY_VERSION_1_22_9        = "kubespray_2_19_1"
+	K8S_VERSION_1_22_9              = "v1.22.9"
+	ETCD_VERSION_1_22_9             = "v3.5.3"
+	CNI_VERSION_1_22_9              = "v1.1.1"
+	CALICO_VERSION_1_22_9           = "v3.22.3"
+	NGINX_INGRESS_CONTROLLER_1_22_9 = "v1.2.1"
+	CONTAINERD_VERSION_1_22_9       = "1.6.4"
 )
 
 const (

--- a/pkg/kubeserver/drivers/clusters/kubespray/environment.go
+++ b/pkg/kubeserver/drivers/clusters/kubespray/environment.go
@@ -69,7 +69,19 @@ func NewDefaultVars(k8sVersion string, extraConf *api.ClusterExtraConfig) Kubesp
 	}
 	vars.DockerOptions = "--bridge=none"
 
-	if strings.Compare(k8sVersion, "v1.19.0") >= 0 {
+	if strings.Compare(k8sVersion, "v1.21.0") >= 0 {
+		vars.CNIVersion = constants.CNI_VERSION_1_22_9
+		vars.CalicoVersion = constants.CALICO_VERSION_1_22_9
+		vars.KubesprayVersion = constants.KUBESPRAY_VERSION_1_22_9
+		vars.ContainerManager = "docker"
+		vars.ContainerdVersion = constants.CONTAINERD_VERSION_1_22_9
+		vars.IngressNginxControllerImageTag = constants.NGINX_INGRESS_CONTROLLER_1_22_9
+		vars.EtcdVersion = constants.ETCD_VERSION_1_22_9
+		calicoctlDownloadUrl := "{{ download_file_url }}/calico/releases/download/{{ calico_version }}/calicoctl-linux-{{ image_arch }}"
+		vars.CalicoctlDownloadUrl = calicoctlDownloadUrl
+		vars.CalicoctlAlternateDownloadUrl = calicoctlDownloadUrl
+		vars.EtcdDownloadUrl = "{{ download_file_url }}/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ image_arch }}.tar.gz"
+	} else if strings.Compare(k8sVersion, "v1.19.0") >= 0 {
 		vars.CNIVersion = constants.CNI_VERSION_1_20_0
 		vars.CalicoVersion = constants.CALICO_VERSION_1_20_0
 		vars.KubesprayVersion = constants.KUBESPRAY_VERSION_1_20_0

--- a/pkg/kubeserver/drivers/clusters/kubespray/kubespray.go
+++ b/pkg/kubeserver/drivers/clusters/kubespray/kubespray.go
@@ -66,7 +66,8 @@ type KubesprayVars struct {
 	DockerOptions            string   `json:"docker_options"`
 	DockerVersion            string   `json:"docker_version"`
 	DockerCliVersion         string   `json:"docker_cli_version"`
-	ContainerdVersion        string   `json:"containerd_version"`
+	ContainerManager         string   `json:"container_manager"`
+	ContainerdVersion        string   `json:"containerd_version,omitempty"`
 
 	// kubespray etcd cluster not support kubeadm managed very well currently
 	// EtcdKubeadmEnabled     bool   `json:"etcd_kubeadm_enabled"`
@@ -89,13 +90,15 @@ type KubesprayVars struct {
 	CrictlDownloadUrl string `json:"crictl_download_url"`
 
 	// etcd related vars
-	EtcdImageRepo string `json:"etcd_image_repo"`
-	EtcdVersion   string `json:"etcd_version"`
+	EtcdImageRepo   string `json:"etcd_image_repo"`
+	EtcdVersion     string `json:"etcd_version"`
+	EtcdDownloadUrl string `json:"etcd_download_url,omitempty"`
 
 	// Calico related vars
 	// CalicoctlDownloadUrl: https://iso.yunion.cn/binaries/calicoctl/releases/download/v3.16.5/calicoctl-linux-amd64
-	CalicoVersion        string `json:"calico_version"`
-	CalicoctlDownloadUrl string `json:"calicoctl_download_url"`
+	CalicoVersion                 string `json:"calico_version"`
+	CalicoctlDownloadUrl          string `json:"calicoctl_download_url"`
+	CalicoctlAlternateDownloadUrl string `json:"calicoctl_alternate_download_url"`
 	// https://github.com/projectcalico/calico/archive/{{ calico_version }}.tar.gz
 	CalicoCRDsDownloadUrl  string `json:"calico_crds_download_url"`
 	CalicoNodeImageRepo    string `json:"calico_node_image_repo"`

--- a/pkg/kubeserver/drivers/clusters/self_build.go
+++ b/pkg/kubeserver/drivers/clusters/self_build.go
@@ -80,6 +80,7 @@ func (d *selfBuildClusterDriver) GetK8sVersions() []string {
 	return []string{
 		constants.K8S_VERSION_1_17_0,
 		constants.K8S_VERSION_1_20_0,
+		constants.K8S_VERSION_1_22_9,
 	}
 }
 

--- a/scripts/sync_image.py
+++ b/scripts/sync_image.py
@@ -160,6 +160,15 @@ class DownloadCalicoctl(DownloadGithubFile):
         return f'calicoctl/releases/download/{self._version}/calicoctl-linux-{self._arch}'
 
 
+class DownloadCalicoctlV2(DownloadGithubFile):
+
+    def __init__(self, dest_dir, version, arch):
+        super(DownloadCalicoctlV2, self).__init__(dest_dir, 'projectcalico', version, arch)
+
+    def get_target_filepath(self):
+        return f'calico/releases/download/{self._version}/calicoctl-linux-{self._arch}'
+
+
 class DownloadCrictl(DownloadGithubFile):
 
     def __init__(self, dest_dir, version, arch):
@@ -187,6 +196,15 @@ class DownloadCalicoCRDs(DownloadGithubFile):
         return f'calico/archive/{self._version}.tar.gz'
 
 
+class DownloadEtcd(DownloadGithubFile):
+
+    def __init__(self, dest_dir, version, arch):
+        super().__init__(dest_dir, 'etcd-io', version, arch)
+
+    def get_target_filepath(self):
+        return f'etcd/releases/download/{self._version}/etcd-{self._version}-linux-{self._arch}.tar.gz'
+
+
 def docker_pull_push(src, target_repo):
     target = os.path.join(target_repo, src.split('/')[-1])
     cmds = [
@@ -208,18 +226,22 @@ def sync_images(repo):
         return Image(src_repo, name, tag, target_repo, name)
     imgs = [
         #Image("docker.io/library", "nginx", "1.19", repo, "nginx"),
-        sameImg(gcr, repo, "coredns", "1.7.0"),
-#        sameImg(gcr, repo, "coredns", "1.8.0"),
+        # sameImg(gcr, repo, "coredns", "1.7.0"),
+        sameImg(gcr, repo, "coredns", "1.8.0"),
        #sameImg(gcr, repo, "nginx-ingress-controller", "v1.0.0"),
          sameImg(gcr, repo, "nginx-ingress-controller", "v0.41.2"),
+       sameImg(gcr, repo, "kube-apiserver", "v1.22.9"),
+       sameImg(gcr, repo, "kube-controller-manager", "v1.22.9"),
+       sameImg(gcr, repo, "kube-proxy", "v1.22.9"),
+       sameImg(gcr, repo, "kube-scheduler", "v1.22.9"),
 #        sameImg(gcr, repo, "kube-apiserver", "v1.20.0"),
 #        sameImg(gcr, repo, "kube-controller-manager", "v1.20.0"),
 #        sameImg(gcr, repo, "kube-proxy", "v1.20.0"),
 #        sameImg(gcr, repo, "kube-scheduler", "v1.20.0"),
-        sameImg(gcr, repo, "kube-apiserver", "v1.17.0"),
-        sameImg(gcr, repo, "kube-controller-manager", "v1.17.0"),
-        sameImg(gcr, repo, "kube-proxy", "v1.17.0"),
-        sameImg(gcr, repo, "kube-scheduler", "v1.17.0"),
+        # sameImg(gcr, repo, "kube-apiserver", "v1.17.0"),
+        # sameImg(gcr, repo, "kube-controller-manager", "v1.17.0"),
+        # sameImg(gcr, repo, "kube-proxy", "v1.17.0"),
+        # sameImg(gcr, repo, "kube-scheduler", "v1.17.0"),
 #        sameImg(gcr, repo, "metrics-server", "v0.5.0"),
 #        sameImg(gcr, repo, "pause", "3.3"),
         # Image("calico", "node", "v3.19.3", repo, "calico-node"),
@@ -228,9 +250,17 @@ def sync_images(repo):
         # Image("calico", "kube-controllers", "v3.19.3", repo, "calico-kube-controllers"),
         # Image("calico", "typha", "v3.19.3", repo, "calico-typha"),
         # Image("calico", "pod2daemon-flexvol", "v3.19.2", repo, "calico-pod2daemon-flexvol"),
+        # Image("calico", "node", "v3.19.3", repo, "calico-node"),
+        Image("calico", "node", "v3.22.3", repo, "calico-node"),
+        Image("calico", "cni", "v3.22.3", repo, "calico-cni"),
+        Image("calico", "kube-controllers", "v3.22.3", repo, "calico-kube-controllers"),
+        Image("calico", "typha", "v3.22.3", repo, "calico-typha"),
+        Image("calico", "pod2daemon-flexvol", "v3.22.3", repo, "calico-pod2daemon-flexvol"),
         # Image('quay.io/coreos', 'etcd', 'v3.4.13', repo, 'etcd', arch=['arm64']),
         # Image("k8s.gcr.io/dns", "k8s-dns-node-cache", "1.16.0", repo, "k8s-dns-node-cache"),
+        Image("k8s.gcr.io/dns", "k8s-dns-node-cache", "1.21.1", repo, "k8s-dns-node-cache"),
         # Image("k8s.grc.io/cpa", "cluster-proportional-autoscaler", "1.8.3", repo, "cluster-proportional-autoscaler"),
+        Image("k8s.grc.io/cpa", "cluster-proportional-autoscaler", "1.8.5", repo, "cluster-proportional-autoscaler"),
     ]
     for i in imgs:
         i.sync_archs_image()
@@ -252,22 +282,32 @@ def download_files():
     fs = [
         # DownloadCalicoctl(output_dir, "v3.19.3", "amd64"),
         # DownloadCalicoctl(output_dir, "v3.19.3", "arm64"),
+        #DownloadCalicoctlV2(output_dir, "v3.22.3", "amd64"),
+        #DownloadCalicoctlV2(output_dir, "v3.22.3", "arm64"),
         # DownloadCrictl(output_dir, 'v1.20.0', "amd64"),
         # DownloadCrictl(output_dir, 'v1.20.0', "arm64"),
+        #DownloadCrictl(output_dir, 'v1.22.0', "amd64"),
+        #DownloadCrictl(output_dir, 'v1.22.0', "arm64"),
         # DownloadCNI(output_dir, 'v0.9.1', 'arm64'),
         # DownloadCNI(output_dir, 'v0.9.1', 'amd64'),
         # DownloadCNI(output_dir, 'v0.8.6', 'arm64'),
         # DownloadCNI(output_dir, 'v0.8.6', 'amd64'),
-        DownloadCalicoCRDs(output_dir, 'v3.19.2'),
+        #DownloadCNI(output_dir, 'v1.1.1', 'arm64'),
+        #DownloadCNI(output_dir, 'v1.1.1', 'amd64'),
+        # DownloadCalicoCRDs(output_dir, 'v3.19.2'),
+        #DownloadCalicoCRDs(output_dir, 'v3.22.3'),
+        DownloadEtcd(output_dir, 'v3.5.3', 'amd64'),
+        DownloadEtcd(output_dir, 'v3.5.3', 'arm64'),
     ]
     # fs.extend(k8s_bins('v1.17.0'))
     # fs.extend(k8s_bins('v1.20.0'))
+    #fs.extend(k8s_bins('v1.22.9'))
     for f in fs:
         f.save_archive()
 
 
 if __name__ == '__main__':
     repo = 'registry.cn-beijing.aliyuncs.com/yunionio'
-    sync_images(repo)
+    #sync_images(repo)
     #docker_cluster_proportional_image(repo)
-    # download_files()
+    download_files()


### PR DESCRIPTION
Cherry pick of #243 on release/3.10.

#243: feat: use kubespray v2.19.1 to deploy k8s 1.22