### PR TITLE
Automated cherry pick of #264: fix(kubeserver): list chart by repo id

### DIFF
--- a/pkg/kubeserver/resources/chart/list.go
+++ b/pkg/kubeserver/resources/chart/list.go
@@ -49,6 +49,7 @@ func (man *SChartManager) List(userCred mcclient.TokenCredential, query *api.Cha
 	if err != nil {
 		return nil, err
 	}
+	query.Repo = repoObj.GetName()
 
 	inputAllVersion := query.AllVersion
 	if len(options.Options.ChartIgnores) != 0 {


### PR DESCRIPTION
Cherry pick of #264 on master.

#264: fix(kubeserver): list chart by repo id