### PR TITLE
fix: update aws cloud-controller-manager image

### DIFF
--- a/pkg/kubeserver/drivers/clusters/addons/cloudprovider_aws.go
+++ b/pkg/kubeserver/drivers/clusters/addons/cloudprovider_aws.go
@@ -172,7 +172,7 @@ spec:
         {}
       containers:
         - name: aws-cloud-controller-manager
-          image: "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
+          image: "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0"
           args:
             - --v=2
             - --cloud-provider=aws


### PR DESCRIPTION
To fix kubectl logs timeout for all pods on some nodes.

Check issue: https://github.com/kubernetes/kops/issues/13752