### PR TITLE
Automated cherry pick of #329: fix(kubeserver): ignore error when sync resource before namespace is not synced

### DIFF
--- a/pkg/kubeserver/drivers/clusters/selfbuild/aws.go
+++ b/pkg/kubeserver/drivers/clusters/selfbuild/aws.go
@@ -81,8 +81,9 @@ func (s *sAwsDriver) GetAddonsHelmCharts(cluster *models.SCluster, conf *api.Clu
 			ReleaseName:    "aws-load-balancer-controller",
 			Namespace:      "kube-system",
 			Values: map[string]interface{}{
-				"replicaCount": 1,
-				"clusterName":  cluster.GetName(),
+				"replicaCount":                1,
+				"clusterName":                 cluster.GetName(),
+				"enableServiceMutatorWebhook": false,
 			},
 		},
 		{

--- a/pkg/kubeserver/models/clusterresource.go
+++ b/pkg/kubeserver/models/clusterresource.go
@@ -561,7 +561,12 @@ func syncClusterResources(
 	for i := 0; i < len(added); i += 1 {
 		newObj, err := NewFromRemoteObject(ctx, userCred, man, cluster, added[i])
 		if err != nil {
-			syncResult.AddError(errors.Wrapf(err, "add object"))
+			if man.IsNamespaceScope() {
+				log.Warningf("sync namespace object error: %s, maybe namespace is not sync to local yet.", err)
+				continue
+			} else {
+				syncResult.AddError(errors.Wrapf(err, "add object"))
+			}
 		} else {
 			localObjs = append(localObjs, newObj)
 			remoteObjs = append(remoteObjs, added[i])


### PR DESCRIPTION
Cherry pick of #329 on master.

#329: fix(kubeserver): ignore error when sync resource before namespace is not synced