### PR TITLE
Automated cherry pick of #334: fix(kubeserver): raise error when get client from imported kubeconfig

### DIFF
--- a/pkg/kubeserver/drivers/clusters/imported_base.go
+++ b/pkg/kubeserver/drivers/clusters/imported_base.go
@@ -119,6 +119,9 @@ func (d *sImportBaseDriver) ValidateCreateData(ctx context.Context, userCred mcc
 	apiServer := importData.ApiServer
 	kubeconfig := importData.Kubeconfig
 	newKubeconfig, restConfig, cli, err := d.getKubeClientByConfig(apiServer, kubeconfig)
+	if err != nil {
+		return httperrors.NewNotSupportedError("get kubernetes client by config: %v", err)
+	}
 	importData.Kubeconfig = string(newKubeconfig)
 	importData.ApiServer = restConfig.Host
 	version, err := cli.Discovery().ServerVersion()

--- a/pkg/kubeserver/drivers/clusters/selfbuild/aws.go
+++ b/pkg/kubeserver/drivers/clusters/selfbuild/aws.go
@@ -120,20 +120,23 @@ func (s *sAwsDriver) GetAddonsManifest(cluster *models.SCluster, conf *api.Clust
 	commonConf.IngressControllerYunionConfig = nil
 	commonConf.CSIYunionConfig = nil
 	commonConf.MetricsPluginConfig = nil
-	commonConf.CSIRancherLocalPathConfig.Image = "registry.cn-beijing.aliyuncs.com/yunionio/local-path-provisioner:v0.0.24"
+	// commonConf.CSIRancherLocalPathConfig.Image = "registry.cn-beijing.aliyuncs.com/yunionio/local-path-provisioner:v0.0.24"
+	commonConf.CSIRancherLocalPathConfig.Image = "rancher/local-path-provisioner:v0.0.24"
+	commonConf.CSIRancherLocalPathConfig.HelperImage = "busybox:latest"
 
-	reg, err := cluster.GetImageRepository()
-	if err != nil {
-		return "", errors.Wrap(err, "get cluster image_repository")
-	}
+	// reg, err := cluster.GetImageRepository()
+	// if err != nil {
+	// 	return "", errors.Wrap(err, "get cluster image_repository")
+	// }
 
 	cniVersion := "v1.13.3"
+	cniUrl := "registry.us-west-1.aliyuncs.com/yunion-dev"
 
 	pluginConf := &addons.AwsVMPluginsConfig{
 		YunionCommonPluginsConfig: commonConf,
 		AwsVPCCNIConfig: &addons.AwsVPCCNIConfig{
-			Image:     registry.MirrorImage(reg.Url, "amazon-k8s-cni", cniVersion, ""),
-			InitImage: registry.MirrorImage(reg.Url, "amazon-k8s-cni-init", cniVersion, ""),
+			Image:     registry.MirrorImage(cniUrl, "amazon-k8s-cni", cniVersion, ""),
+			InitImage: registry.MirrorImage(cniUrl, "amazon-k8s-cni-init", cniVersion, ""),
 		},
 		CloudProviderAwsConfig: &addons.CloudProviderAwsConfig{},
 	}


### PR DESCRIPTION
Cherry pick of #334 on master.

#334: fix(kubeserver): raise error when get client from imported kubeconfig