### PR TITLE
fix: kubeserver automatically purge spitable logs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -24,7 +24,7 @@ jobs:
           set -o xtrace
           workdir="$HOME/go/src/yunion.io/x"
           mkdir -p "$workdir"
-          mv "$HOME/work/pkg/kubecomps" "$workdir/"
+          mv "$HOME/work/kubecomps/kubecomps" "$workdir/"
 
           export GOPATH="$HOME/go"
           export GO111MODULE=off

--- a/pkg/kubeserver/initial/client.go
+++ b/pkg/kubeserver/initial/client.go
@@ -6,6 +6,7 @@ import (
 	// "k8s.io/apimachinery/pkg/util/wait"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 
 	"yunion.io/x/kubecomps/pkg/kubeserver/client"
 	"yunion.io/x/kubecomps/pkg/kubeserver/models"
@@ -20,6 +21,8 @@ import (
 func InitClient(cron *cronman.SCronJobManager) {
 	// go wait.Forever(client.BuildApiserverClient, 5*time.Second)
 	client.InitClustersManager(manager.ClusterManager())
+
+	cron.AddJobEveryFewHour("AutoPurgeSplitable", 4, 30, 0, db.AutoPurgeSplitable, false)
 
 	cron.AddJobAtIntervalsWithStartRun("StartKubeClusterHealthCheck", 5*time.Minute, models.ClusterManager.ClusterHealthCheckTask, true)
 	cron.AddJobAtIntervalsWithStartRun("StartKubeClusterAutoSyncTask", 30*time.Minute, models.ClusterManager.StartAutoSyncTask, true)


### PR DESCRIPTION
fix: kubeserver automatically purge spitable logs