### PR TITLE
Automated cherry pick of #413: fix(kubeserver): client without auth info

### DIFF
--- a/pkg/kubeserver/drivers/container_registries/common.go
+++ b/pkg/kubeserver/drivers/container_registries/common.go
@@ -39,7 +39,11 @@ func (c commonImpl) GetType() api.ContainerRegistryType {
 
 func (c commonImpl) GetDockerRegistryClient(url string, config *api.ContainerRegistryConfig) (client.Client, error) {
 	if config.Common == nil {
-		return nil, errors.Errorf("harbor config is nil")
+		// return nil, errors.Errorf("harbor config is nil")
+		return client.NewClient(url, client.DockerAuthConfig{
+			Username: "",
+			Password: "",
+		})
 	}
 	return client.NewClient(url, client.DockerAuthConfig{
 		Username: config.Common.Username,

--- a/pkg/kubeserver/models/container_registries.go
+++ b/pkg/kubeserver/models/container_registries.go
@@ -160,6 +160,11 @@ func (r *SContainerRegistry) GetConfig() (*api.ContainerRegistryConfig, error) {
 		conf.Type = api.ContainerRegistryType(r.Type)
 		return conf, nil
 	}
+	if r.CredentialId == "" {
+		return &api.ContainerRegistryConfig{
+			Type: api.ContainerRegistryType(r.Type),
+		}, nil
+	}
 	return r.getConfigByCredential()
 }
 


### PR DESCRIPTION
Cherry pick of #413 on release/4.0.2.

#413: fix(kubeserver): client without auth info