### PR TITLE
Automated cherry pick of #424: fix(helm): skip TLS verify when locating chart path

### DIFF
--- a/pkg/kubeserver/helm/chart.go
+++ b/pkg/kubeserver/helm/chart.go
@@ -213,6 +213,7 @@ func (c ChartClient) LocateChartPath(repoName, chartName, version string, repo *
 	}
 
 	pathOpt := c.NewChartPathOptions(version, false, repo)
+	pathOpt.InsecureSkipTLSverify = true
 
 	chartName = strings.Join([]string{repoName, chartName}, "/")
 


### PR DESCRIPTION
Cherry pick of #424 on master.

#424: fix(helm): skip TLS verify when locating chart path