### PR TITLE
fix(ocnet-cni): add cloud metadata routes on default NIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,5 +120,17 @@ test:
 
 .PHONY: fmt fmt-check test
 
+.PHONY: ocnet-cni ocnet-cni-amd64 ocnet-cni-arm64
+
+ocnet-cni: ocnet-cni-amd64 ocnet-cni-arm64
+
+ocnet-cni-amd64: prepare_dir
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO_BUILD) \
+		-o $(BIN_DIR)/ocnet-cni-amd64 $(REPO_PREFIX)/cmd/ocnet-cni
+
+ocnet-cni-arm64: prepare_dir
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GO_BUILD) \
+		-o $(BIN_DIR)/ocnet-cni-arm64 $(REPO_PREFIX)/cmd/ocnet-cni
+
 %:
 	@:

--- a/cmd/ocnet-cni/main.go
+++ b/cmd/ocnet-cni/main.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/version"
 
 	"yunion.io/x/kubecomps/pkg/cni-plugin/plugin"
 )
@@ -14,7 +15,7 @@ func main() {
 	_, filename := filepath.Split(os.Args[0])
 	switch filename {
 	case "ocnet-cni":
-		plugin.Main("unknown version")
+		plugin.Main(version.Get().String())
 	default:
 		log.Fatalf("Unsupported %s", filename)
 	}

--- a/pkg/cni-plugin/plugin/utils.go
+++ b/pkg/cni-plugin/plugin/utils.go
@@ -174,6 +174,12 @@ func getNetworkConfig(idx int, nic PodNic, defaultGw bool) (*current.Interface, 
 		}
 		routes = append(routes, route)
 
+		// always add 169.254.169.254 for default NIC (align with onecloud AddNicRoutes)
+		_, mdNet, _ := net.ParseCIDR("169.254.169.254/32")
+		routes = append(routes, &types.Route{
+			Dst: *mdNet,
+			GW:  net.ParseIP("0.0.0.0"),
+		})
 	}
 	// process ipv6
 	if nic.Ip6 != "" {
@@ -199,6 +205,13 @@ func getNetworkConfig(idx int, nic PodNic, defaultGw bool) (*current.Interface, 
 				GW:  defaultGateway6,
 			}
 			routes = append(routes, route6)
+
+			// always add fd00:ec2::254 for default NIC (align with onecloud AddNicRoutes)
+			_, mdNet6, _ := net.ParseCIDR("fd00:ec2::254/128")
+			routes = append(routes, &types.Route{
+				Dst: *mdNet6,
+				GW:  net.ParseIP("::"),
+			})
 		}
 	}
 

--- a/pkg/cni-plugin/plugin/utils_test.go
+++ b/pkg/cni-plugin/plugin/utils_test.go
@@ -1,8 +1,11 @@
 package plugin
 
 import (
+	"net"
 	"reflect"
 	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 func Test_parseCNIArgs(t *testing.T) {
@@ -39,4 +42,82 @@ func Test_parseCNIArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getNetworkConfig_metadataRoutes(t *testing.T) {
+	mustCIDR := func(s string) net.IPNet {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			t.Fatalf("ParseCIDR(%q): %v", s, err)
+		}
+		return *n
+	}
+
+	nic := PodNic{
+		Interface: "eth0",
+		Mac:       "00:11:22:33:44:55",
+		Ip:        "192.168.1.100",
+		Masklen:   24,
+		Gateway:   "192.168.1.1",
+	}
+
+	t.Run("defaultGw true ipv4 only", func(t *testing.T) {
+		_, _, routes, err := getNetworkConfig(0, nic, true)
+		if err != nil {
+			t.Fatalf("getNetworkConfig: %v", err)
+		}
+		want := []*types.Route{
+			{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("192.168.1.1")},
+			{Dst: mustCIDR("169.254.169.254/32"), GW: net.ParseIP("0.0.0.0")},
+		}
+		if !routesEqual(routes, want) {
+			t.Errorf("routes = %#v, want %#v", routes, want)
+		}
+	})
+
+	t.Run("defaultGw false no metadata route", func(t *testing.T) {
+		_, _, routes, err := getNetworkConfig(1, nic, false)
+		if err != nil {
+			t.Fatalf("getNetworkConfig: %v", err)
+		}
+		if len(routes) != 0 {
+			t.Errorf("routes = %#v, want empty", routes)
+		}
+	})
+
+	t.Run("defaultGw true with ipv6", func(t *testing.T) {
+		nic6 := nic
+		nic6.Ip6 = "2001:db8::100"
+		nic6.Masklen6 = 64
+		nic6.Gateway6 = "2001:db8::1"
+
+		_, _, routes, err := getNetworkConfig(0, nic6, true)
+		if err != nil {
+			t.Fatalf("getNetworkConfig: %v", err)
+		}
+		want := []*types.Route{
+			{Dst: mustCIDR("0.0.0.0/0"), GW: net.ParseIP("192.168.1.1")},
+			{Dst: mustCIDR("169.254.169.254/32"), GW: net.ParseIP("0.0.0.0")},
+			{Dst: mustCIDR("::/0"), GW: net.ParseIP("2001:db8::1")},
+			{Dst: mustCIDR("fd00:ec2::254/128"), GW: net.ParseIP("::")},
+		}
+		if !routesEqual(routes, want) {
+			t.Errorf("routes = %#v, want %#v", routes, want)
+		}
+	})
+}
+
+func routesEqual(got, want []*types.Route) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i].Dst.String() != want[i].Dst.String() {
+			return false
+		}
+		if !got[i].GW.Equal(want[i].GW) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Align with onecloud AddNicRoutes by injecting 169.254.169.254 and fd00:ec2::254; also wire real version string and multi-arch build targets.